### PR TITLE
Fix nils for class, race, sex during PLAYER_LOGIN

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -948,7 +948,9 @@ event_frame:SetScript("OnEvent", function (self, event, ...)
     elseif event == "PLAYER_LOGIN" then
         local name = UnitName("player")
         local guid = UnitGUID("player")
-        local _, class, _, race, sex = GetPlayerInfoByGUID(guid)
+        local _, class = UnitClass("player")
+        local _, race = UnitRace("player")
+        local sex = UnitSex("player")
         local faction = UnitFactionGroup("player")
 
         -- print("PLAYER_LOGIN", name, race, class, sex, faction)


### PR DESCRIPTION
GetPlayerInfoByGUID retrieves nils during the PLAYER_LOGIN event, so that there is an error:
`Message: Interface\AddOns\ClassicUA\main.lua:171: attempt to index field '?' (a nil value)`

The GetPlayerInfoByGUID call was replaced by corresponding functions.